### PR TITLE
implement rsvp and crud operations on events

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,5 +14,7 @@ def create_app(config_name):
 	db.init_app(app)
 	from .auth import auth as auth_blueprint
 	app.register_blueprint(auth_blueprint, url_prefix='/auth')
+	from .events import events as events_blueprint
+	app.register_blueprint(events_blueprint, url_prefix='/events')
 	return app
 	

--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -18,7 +18,7 @@ def before_request():
 					#find the user with the id on the token
 					user = User.query.filter_by(id=res).first()
 					g.user = user
-			
+
 @auth.route('/register', methods=['POST'])
 def register():
 	""" a route to register a user"""

--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -13,12 +13,12 @@ def before_request():
 			if access_token:
 				#try decoding the token and get the user_id
 				res = User.decode_token(access_token)
-				if type(res) is int:
+				if isinstance(res, int):
 					#check if no error in string format was returned
 					#find the user with the id on the token
 					user = User.query.filter_by(id=res).first()
 					g.user = user
-					
+			
 @auth.route('/register', methods=['POST'])
 def register():
 	""" a route to register a user"""

--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -7,17 +7,18 @@ def before_request():
 	"""get the user bafore every request"""
 	if request.endpoint and request.blueprint != 'auth':
 		auth_header = request.headers.get('Authorization')
-		access_token = auth_header.split(" ")[1]
-		if access_token:
-			#try decoding the token and get the user_id
-			res = User.decode_token(access_token)
-			g.user = None
-			if type(res) is int:
-				#check if no error in string format was returned
-				#find the user with the id on the token
-				user = User.query.filter_by(id=res).first()
-				g.user = user
-			
+		g.user = None
+		if auth_header:
+			access_token = auth_header.split(" ")[1]
+			if access_token:
+				#try decoding the token and get the user_id
+				res = User.decode_token(access_token)
+				if type(res) is int:
+					#check if no error in string format was returned
+					#find the user with the id on the token
+					user = User.query.filter_by(id=res).first()
+					g.user = user
+					
 @auth.route('/register', methods=['POST'])
 def register():
 	""" a route to register a user"""

--- a/app/auth/views.py
+++ b/app/auth/views.py
@@ -1,7 +1,23 @@
-from flask import request, jsonify
+from flask import request, jsonify, g
 from app.models import User
 from . import auth
 
+@auth.before_app_request
+def before_request():
+	"""get the user bafore every request"""
+	if request.endpoint and request.blueprint != 'auth':
+		auth_header = request.headers.get('Authorization')
+		access_token = auth_header.split(" ")[1]
+		if access_token:
+			#try decoding the token and get the user_id
+			res = User.decode_token(access_token)
+			g.user = None
+			if type(res) is int:
+				#check if no error in string format was returned
+				#find the user with the id on the token
+				user = User.query.filter_by(id=res).first()
+				g.user = user
+			
 @auth.route('/register', methods=['POST'])
 def register():
 	""" a route to register a user"""

--- a/app/events/__init__.py
+++ b/app/events/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+events = Blueprint('events', __name__)
+
+from . import views

--- a/app/events/views.py
+++ b/app/events/views.py
@@ -86,9 +86,8 @@ def manipulate_event(event_id):
 		if event:
 			#maeke sure the events is modified by the right person
 			if event.created_by.username == g.user.username:
-				if request.method == 'PUT':
-				#get the incoming details 
-					event_details = request.get_json()
+				if request.method == 'PUT': 
+					event_details = request.get_json() #get the incoming details
 					#update the details accordingly
 					event.name = event_details['name']
 					event.description = event_details['description']

--- a/app/events/views.py
+++ b/app/events/views.py
@@ -35,23 +35,25 @@ def create():
 @events.route('/all')
 def get_all():
 	"""fetch all events available"""
-	events = Events.get_all()
-	if events:
-		event_list = []
-		for event in events:
-			evnt = {
-				"id" : event.id,
-				"name" : event.name,
-				"description" : event.description,
-				"category" : event.category,
-				"location" : event.location,
-				"created_by" : event.created_by.username,
-				"event_date" : event.event_date,
-				"date_created" : event.date_created
-			}
-			event_list.append(evnt)
-		return jsonify(event_list), 200
-	return jsonify({"message" : "no events created yet"}), 200
+	if g.user:
+		events = Events.get_all()
+		if events:
+			event_list = []
+			for event in events:
+				evnt = {
+					"id" : event.id,
+					"name" : event.name,
+					"description" : event.description,
+					"category" : event.category,
+					"location" : event.location,
+					"created_by" : event.created_by.username,
+					"event_date" : event.event_date,
+					"date_created" : event.date_created
+				}
+				event_list.append(evnt)
+			return jsonify(event_list), 200
+		return jsonify({"message" : "no events created yet"}), 200
+	return jsonify({"message" : "please login or register view events"}), 401
 
 @events.route('/myevents')
 def my_events():
@@ -75,3 +77,92 @@ def my_events():
 			return jsonify(event_list), 200
 		return jsonify({"message" : "you have not created any events yet"}), 200
 	return jsonify({"message" : "please login to access your events"}), 401
+
+@events.route('/<int:event_id>', methods=['PUT', 'DELETE' , 'GET' ])
+def manipulate_event(event_id):
+	"""update or delete an event"""
+	if g.user:
+		event = Events.get_event_by_id(event_id)
+		if event:
+			#maeke sure the events is modified by the right person
+			if event.created_by.username == g.user.username:
+				if request.method == 'PUT':
+					#get the incoming details 
+					event_details = request.get_json()
+					#update the details accordingly
+					event.name = event_details['name']
+					event.description = event_details['description']
+					event.category = event_details['category']
+					event.location = event_details['location']
+					event.event_date = event_details['event_date']
+					#save the event back to the database
+					event.save()
+					return jsonify({"message" : "event updated successfully"}), 200
+				elif request.method == 'GET':
+					#return the event with the given id
+					found_event = {
+						'id' : event.id,
+						'description' : event.description,
+						'category' : event.category,
+						'location' : event.location,
+						'created_by' : event.created_by.username,
+						'event date' : event.event_date,
+						'date created' : event.date_created
+					}
+					return jsonify(found_event), 200
+				else:
+				#if the request method is delete
+					event.delete()
+					return jsonify({"message" : "event deleted successfully"}), 200
+			return jsonify({"message" : "you can not modify the event"})
+		return jsonify({"message" : "no event with given id found"}), 404
+	return jsonify({"message" : "please login or register  to create an event"}), 401
+
+@events.route('/<int:event_id>/rsvp', methods=['POST', 'GET'])
+def rsvp(event_id):
+	"""register a user to an event"""
+	if g.user:
+		event = Events.get_event_by_id(event_id)
+		if event:
+			if request.method == 'POST':
+				res = event.add_rsvp(g.user)
+				if res == "rsvp success":
+					return jsonify({"message" : "rsvp success, see you then"}), 201
+				return jsonify({"message" : "already registered for this event"}), 302
+			rsvps = event.rsvps.all()
+			if rsvps:
+				rsvp_list = []
+				for user in rsvps:
+					rsvp= {
+						"username" : user.username,
+						"email" : user.email
+					}
+					rsvp_list.append(rsvp)
+				return jsonify(rsvp_list), 200
+			return jsonify({"message" : "no users have responded to this event yet"}),200
+		return jsonify({"message" : "event does not exist"}), 404
+	return jsonify({"message" : "please login or signup to rsvp"}), 401
+
+@events.route('/myrsvps')
+def my_rsvps():
+	"""return the list of events that user has responded to"""
+	if g.user:
+		rsvps = g.user.myrsvps.all()
+		if rsvps:
+			rsvp_list = []
+			for event in rsvps:
+				rsvp = {
+					"event name" : event.name,
+					"location" : event.location,
+					"orgarniser" : event.created_by,
+					"event date" : event.event_date
+				}
+				rsvp_list.append(rsvp)
+			return jsonify(rsvp_list), 200
+		return jsonify({"message" : "you have not responded to any events yet"}), 200
+	return jsonify({"message" : "please login or signup to see your rsvps"}), 401
+
+
+
+
+

--- a/app/events/views.py
+++ b/app/events/views.py
@@ -87,7 +87,7 @@ def manipulate_event(event_id):
 			#maeke sure the events is modified by the right person
 			if event.created_by.username == g.user.username:
 				if request.method == 'PUT':
-					#get the incoming details 
+				#get the incoming details 
 					event_details = request.get_json()
 					#update the details accordingly
 					event.name = event_details['name']

--- a/app/events/views.py
+++ b/app/events/views.py
@@ -1,0 +1,26 @@
+from flask import request, jsonify,g
+from app.models import Events
+from . import events
+@events.route('/create', methods=['POST'])
+def create():
+	"""a route to handle creating an event"""
+	if g.user:
+		event_details = request.get_json()
+		name = event_details['name']
+		description = event_details['description']
+		category = event_details['category']
+		location = event_details['location']
+		event_date = event_details['event_date']
+		created_by = g.user
+		event = Events(name=name, description=description, category=category, \
+			location=location, event_date=event_date, created_by=created_by)
+		event.save()
+		res = {
+			"id" : event.id,
+			"name" : event.name,
+			"date_created" : event.date_created,
+			"created_by" : event.created_by.username
+			}
+		return jsonify(res), 201
+	return jsonify({"message" : "please login or register to create an event"})
+	

--- a/app/events/views.py
+++ b/app/events/views.py
@@ -154,7 +154,7 @@ def my_rsvps():
 				rsvp = {
 					"event name" : event.name,
 					"location" : event.location,
-					"orgarniser" : event.created_by,
+					"orgarniser" : event.created_by.username,
 					"event date" : event.event_date
 				}
 				rsvp_list.append(rsvp)

--- a/app/events/views.py
+++ b/app/events/views.py
@@ -12,15 +12,66 @@ def create():
 		location = event_details['location']
 		event_date = event_details['event_date']
 		created_by = g.user
-		event = Events(name=name, description=description, category=category, \
-			location=location, event_date=event_date, created_by=created_by)
-		event.save()
-		res = {
-			"id" : event.id,
-			"name" : event.name,
-			"date_created" : event.date_created,
-			"created_by" : event.created_by.username
+		#check if the user has an event with a similar name and location
+		existing_event = [event for event in g.user.events if event.name == name \
+			and event.location == location]
+		if not existing_event:
+			#create the event if does not exist
+			event = Events(name=name, description=description, category=category, \
+				location=location, event_date=event_date, created_by=created_by)
+			event.save()
+			res = {
+				"id" : event.id,
+				"name" : event.name,
+				"category" : event.category,
+				"created_by" : event.created_by.username,
+				"location" : event.location,
+				"date_created" : event.date_created
+				}
+			return jsonify(res), 201
+		return jsonify({"message" : "you have a similar event in the same location"}), 302
+	return jsonify({"message" : "please login or register  to create an event"}), 401
+
+@events.route('/all')
+def get_all():
+	"""fetch all events available"""
+	events = Events.get_all()
+	if events:
+		event_list = []
+		for event in events:
+			evnt = {
+				"id" : event.id,
+				"name" : event.name,
+				"description" : event.description,
+				"category" : event.category,
+				"location" : event.location,
+				"created_by" : event.created_by.username,
+				"event_date" : event.event_date,
+				"date_created" : event.date_created
 			}
-		return jsonify(res), 201
-	return jsonify({"message" : "please login or register to create an event"})
-	
+			event_list.append(evnt)
+		return jsonify(event_list), 200
+	return jsonify({"message" : "no events created yet"}), 200
+
+@events.route('/myevents')
+def my_events():
+	"""fetch all events belonging to a particular user"""
+	if g.user:
+		events = g.user.events
+		if events:
+			event_list = []
+			for event in events:
+				evnt ={
+					"id" : event.id,
+					"name" : event.name,
+					"description" : event.description,
+					"category" : event.category,
+					"location" : event.location,
+					"created_by" : event.created_by.username,
+					"event_date" : event.event_date,
+					"date_created" : event.date_created
+				}
+				event_list.append(evnt)
+			return jsonify(event_list), 200
+		return jsonify({"message" : "you have not created any events yet"}), 200
+	return jsonify({"message" : "please login to access your events"}), 401

--- a/app/models.py
+++ b/app/models.py
@@ -93,7 +93,9 @@ class Events(db.Model):
 		""" This method adds a user to the list of rsvps"""
 		if not self.has_rsvp(user):
 			self.rsvps.append(user)
-			db.session.add(self)
+			self.save()
+			return "rsvp success"
+		return "already registered"
 
 	def has_rsvp(self, user):
 		"""This method checks if a user is already registered for an event"""
@@ -114,6 +116,11 @@ class Events(db.Model):
 	def get_all():
 		"""a method to fetch all events"""
 		return Events.query.all()
+
+	@staticmethod
+	def get_event_by_id(event_id):
+		"""get an event with the given id"""
+		return Events.query.filter_by(id=event_id).first()
 
 	def __repr__(self):
 		return '<Events %r>' % self.name

--- a/tests/test_event_model.py
+++ b/tests/test_event_model.py
@@ -1,0 +1,69 @@
+import unittest
+import json
+from datetime import datetime
+from app import create_app, db
+from app.models import User
+
+class UserModelTest(unittest.TestCase):
+	"""test the functionalities of the user model"""
+
+	def setUp(self):
+		self.app = create_app('testing')
+		self.app_context = self.app.app_context()
+		self.app_context.push()
+		self.client = self.app.test_client
+		db.create_all()
+		self.user_data = json.dumps({
+				'username' : 'test_user',
+				'email' : 'test@test.com',
+				'password' : 'test_password'
+			})
+		self.event_data = json.dumps({
+				'name' : 'eventname',
+				'description' : 'sample event description',
+				'category' : 'event_testing',
+				'location' : 'the space',
+				'event_date' : '2019-12-30'
+			})
+
+		with self.app.app_context():
+			db.session.close()
+			db.drop_all()
+			db.create_all()
+
+	def tearDown(self):
+		db.session.remove()
+		db.drop_all()
+		self.app_context.pop()
+
+	def  register_user(self, username='test_user', email='test@test.com', password='test_password'):
+		"""helper function to register a user"""
+		user_data = json.dumps({
+				'username' : username,
+				'email' : email,
+				'password' : password
+			})
+		return self.client().post('/auth/register', data=user_data, content_type='application/json')
+
+	def  login_user(self, username='test_user', email='test@test.com', password='test_password'):
+		"""helper function to login a user"""
+		user_data = json.dumps({
+				'username' : username,
+				'email' : email,
+				'password' : password
+			})
+		return self.client().post('/auth/login', data=user_data, content_type='application/json')
+
+	def test_create_event(self):
+		"""test an event can be created successfully"""
+		self.register_user()
+		result = self.login_user()
+		#get the access_token to be sent with the request
+		access_token = json.loads(result.data.decode())['access_token']
+		#create an event
+		res = self.client().post('/events/create',
+			headers=dict(Authorization="Bearer " + access_token),
+			data=self.event_data, content_type='application/json')
+		self.assertEqual(res.status_code, 201)
+		self.assertIn('eventname', str(res.data))
+

--- a/tests/test_event_model.py
+++ b/tests/test_event_model.py
@@ -34,21 +34,21 @@ class UserModelTest(unittest.TestCase):
 		db.drop_all()
 		self.app_context.pop()
 
-	def  register_user(self, username='test_user', email='test@test.com', password='test_password'):
+	def  register_user(self, username='test_user', email='test@test.com', passw='test_password'):
 		"""helper function to register a user"""
 		user_data = json.dumps({
 				'username' : username,
 				'email' : email,
-				'password' : password
+				'password' : passw
 			})
 		return self.client().post('/auth/register', data=user_data, content_type='application/json')
 
-	def  login_user(self, username='test_user', email='test@test.com', password='test_password'):
+	def  login_user(self, username='test_user', email='test@test.com', passw='test_password'):
 		"""helper function to login a user"""
 		user_data = json.dumps({
 				'username' : username,
 				'email' : email,
-				'password' : password
+				'password' : passw
 			})
 		return self.client().post('/auth/login', data=user_data, content_type='application/json')
 


### PR DESCRIPTION
**What does this PR do?**

implement events CRUD operations and rsvp 

**Description of tasks to be completed?**

- create events blueprint 
- write tests for events endpoints
- implement creating, viewing, updating  and deleting of a single event
- enable viewing of events belonging to a particular user as well as other events.
- enable responding to events (rsvp)
- implement viewing of users who have responded to an event as well as events a user has responded to.

**How should this be tested manually?**

- pull the latest changes, `git checkout ft-event-crud-153998919` then run `python manage.py test` from the application root directory.
- to test the endpoints with postman, start the server and hit the following endpoints:

     `/events/create`   [POST] create an event
     `/events/all` [GET] get all events 
     `/events/myevents`  [GET] get personal events
     `/events/event_id` [GET] get specific event
     `/events/event_id`  [PUT] update event
    `/events/event_id` [DELETE] delete event
     `/events/event_id/rsvp` [POST] rsvp to event
     `/events/event_id/rsvp` [GET] get all rsvps to this event
     `/events/myrsvps` [GET] get events one responded to

**Relevant tracker stories**
#153998919
#152997726
