### PR TITLE
implement pagination 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ services:
   - postgresql
 before_script:
   - psql -c 'create database brighteventstest;' -U postgres
-script: nosetests --with-coverage --cover-package=tests && coverage report
+script: nosetests --with-coverage --cover-package=app && coverage report
 after_success: coveralls

--- a/app/events/views.py
+++ b/app/events/views.py
@@ -40,7 +40,7 @@ def get_all(page=1):
 				evnt = event.to_json()
 				event_list.append(evnt)
 			return jsonify(event_list), 200
-		return jsonify({"message" : "this page has no events, try previous one"}), 200
+		return jsonify({"message" : "this page has no events, or no events available"}), 200
 	return jsonify({"message" : "please login or register view events"}), 401
 
 @events.route('/myevents')

--- a/app/events/views.py
+++ b/app/events/views.py
@@ -32,7 +32,7 @@ def get_all(page=1):
 	"""fetch all events available"""
 	if g.user:
 		#fetch the first 15 events based on event date
-		result = Events.query.order_by(Events.event_date.asc()).paginate(page=page, per_page=1, error_out=False)
+		result = Events.query.order_by(Events.event_date.asc()).paginate(page=page, per_page=15, error_out=False)
 		if result.items:
 			event_list = []
 			for event in result.items:

--- a/app/events/views.py
+++ b/app/events/views.py
@@ -1,4 +1,3 @@
-from functools import wraps
 from flask import request, jsonify,g
 from app.models import Events
 from . import events

--- a/app/models.py
+++ b/app/models.py
@@ -73,6 +73,27 @@ class User(db.Model):
 			# the token is invalid, return an error message
 			return "Please register or login"
 
+	#this will be used to test pagination
+	@staticmethod
+	def generate_fake_users(count=20):
+		"""try genarating 20 fake users"""
+		from sqlalchemy.exc import IntegrityError
+		from random import seed
+		import forgery_py
+
+		seed()
+		for i in range(count):
+			user  = User(username=forgery_py.internet.user_name(True),
+					email=forgery_py.internet.email_address(),
+					password=forgery_py.lorem_ipsum.word())
+			db.session.add(user)
+			try:
+				#try saving the user to db
+				db.session.commit()
+			except IntegrityError:
+				#if generated email or username already exists
+				db.session.rollback()
+
 	def __repr__(self):
 		return '<User %r>' % self.username
 
@@ -144,6 +165,29 @@ class Events(db.Model):
 	def get_events_by_location(location):
 		"""filter events by location"""
 		return Events.query.filter_by(location=location).order_by(Events.event_date.desc()).all()
+
+	#this will be used to test pagination
+	@staticmethod
+	def generate_fake_events(count=100):
+		"""generate 100 fake events"""
+		import random
+		import forgery_py
+
+		random.seed()
+		categories = ["technology", "social", "education", "family"]
+		user_count = User.query.count()
+		for i in range(count):
+			#pick a random user to be the event creator
+			user = User.query.offset(random.randint(0, user_count - 1)).first()
+			event = Events(name=forgery_py.lorem_ipsum.word(),
+					description=forgery_py.lorem_ipsum.sentences(),
+					category=random.choice(categories),
+					location=forgery_py.address.city(),
+					event_date = forgery_py.date.date(True),
+					created_by = user
+					)
+			db.session.add(event)
+			db.session.commit()
 
 	def __repr__(self):
 		return '<Events %r>' % self.name

--- a/tests/test_event_model.py
+++ b/tests/test_event_model.py
@@ -166,8 +166,8 @@ class UserModelTest(unittest.TestCase):
 		res = self.client().get('/events/myevents',
 			headers=dict(Authorization="Bearer " + access_token), content_type='application/json')
 		result = json.loads(res.data.decode())
-		self.assertEqual(result[0]['created_by'], 'test_user')
-		self.assertNotEqual(result[0]['created_by'], 'test_user2')
+		self.assertEqual(result[0]['orgarniser'], 'test_user')
+		self.assertNotEqual(result[0]['orgarniser'], 'test_user2')
 	def test_update_event(self):
 		"""test if an event owner can update an event"""
 		access_token = self.get_access_token()

--- a/tests/test_event_model.py
+++ b/tests/test_event_model.py
@@ -142,7 +142,7 @@ class UserModelTest(unittest.TestCase):
 		access_token = self.get_access_token()
 		res = self.client().get('/events/all',
 			headers=dict(Authorization="Bearer " + access_token), content_type='application/json')
-		self.assertIn('no events created yet', str(res.data))
+		self.assertIn('no events available', str(res.data))
 
 	def test_get_user_events(self):
 		"""test fecthing events belonging to a particular user"""


### PR DESCRIPTION
**What does this PR do?**
implement pagination when retrieving all events

**Description of tasks to be completed?**
add methods to populate the database with fake users and events
add a route to take the optional pagination page argument
implement pagination to return results in portions 

**How should this be tested manually?**

- start a shell session `python manage.py shell`
- populate users `User.generate_fake_users(number_of_users)`.
- populate events `Events.generate_fake_events(number_of_events)`
-  the  above methods takes an optional argument of the number of users or events you want to generate.
- run the app and send a `GET` request to `events/all/<int:page>`

**Relevant tracker stories**
154303408